### PR TITLE
Fixed "Manual Setup back button closes app" issue: Updated AccountSetupBasics.java

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -332,8 +332,6 @@ public class AccountSetupBasics extends K9Activity
         mAccount.setTransportUri(transportUri);
 
         AccountSetupAccountType.actionSelectAccountType(this, mAccount, false);
-
-        finish();
     }
 
     public void onClick(View v) {


### PR DESCRIPTION
removed the finish() at the end of the method onManualSetup(). This was not allowing the user return to this Activity after the user clicked on "Manual setup".

Please ensure that your pull request meets the following requirements - thanks !

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle).
* Does not break any unit tests.
* Contains a reference to the issue that it fixes.
* For cosmetic changes add one or multiple images, if possible.


